### PR TITLE
Fix unittest constraint to not get incompatible version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,4 +9,4 @@ dependencies:
   collection: '^1.1.0'
 dev_dependencies:
   browser: any
-  unittest: any
+  unittest: '<0.12.0'


### PR DESCRIPTION
Unittest have been updated in a not backwards-compatible way, until tests are upgraded to support 0.12.0 the old version needs to be used.
