### PR TITLE
Add support for boolean and numeric values for attrs

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -60,25 +60,25 @@ Future mountComponent(Component component, html.Node node) {
 
 VNode vText(String data, {Object key}) => new VNode.text(data, key: key);
 
-VNode vElement(String tag, {Object key, String type, Map<String, String> attrs,
+VNode vElement(String tag, {Object key, String type, Map<String, dynamic> attrs,
   Map<String, String> style, List<String> classes, List<VNode> children,
   bool content: false}) =>
       new VNode.element(tag, key: key, type: type, attrs: attrs, style: style,
           classes: classes, children: children, content: content);
 
-VNode vSvgElement(String tag, {Object key, String type, Map<String, String> attrs,
+VNode vSvgElement(String tag, {Object key, String type, Map<String, dynamic> attrs,
   Map<String, String> style, List<String> classes, List<VNode> children,
   bool content: false}) =>
       new VNode.svgElement(tag, key: key, type: type, attrs: attrs, style: style,
           classes: classes, children: children, content: content);
 
-VNode vRoot({String type, Map<String, String> attrs, Map<String, String> style,
+VNode vRoot({String type, Map<String, dynamic> attrs, Map<String, String> style,
   List<String> classes, List<VNode> children, bool content: false}) =>
       new VNode.root(type: type, attrs: attrs, style: style,
           classes: classes, children: children, content: content);
 
 VNode vComponent(componentConstructor componentType, {Object key, dynamic data,
-  String type, Map<String, String> attrs, Map<String, String> style,
+  String type, Map<String, dynamic> attrs, Map<String, String> style,
   List<String> classes, List<VNode> children}) =>
       new VNode.component(componentType, key: key, data: data, type: type,
           attrs: attrs, style: style, classes: classes, children: children);

--- a/lib/src/vnode.dart
+++ b/lib/src/vnode.dart
@@ -192,15 +192,7 @@ class VNode {
 
       if (attrs != null) {
         attrs.forEach((k, v) {
-          if (v is num) {
-            v = v.toString();
-          } else if (v is bool) {
-            if (!v) {
-              return;
-            }
-            v = '';
-          }
-          r.attributes[k] = v;
+          _setAttr(r.attributes, k, v);
         });
       }
 
@@ -1014,6 +1006,22 @@ List<int> _lis(List<int> a) {
   return result;
 }
 
+/// Set the attribute [key] to attribute map [attrs].
+///
+/// [value] can be of type String, num or bool. In case of bool it will treated as an
+/// boolean HTML attribute and will be set to an empty value on true or dismissed on false.
+_setAttr(Map<String, String> attrs, String key, value) {
+  if (value is num) {
+    value = value.toString();
+  } else if (value is bool) {
+    if (!value) {
+      return;
+    }
+    value = '';
+  }
+  attrs[key] = value;
+}
+
 /// Find changes between maps [a] and [b] and apply this changes to CssStyleDeclaration [n].
 void updateStyle(Map a, Map b, html.CssStyleDeclaration style) {
   assert(style != null);
@@ -1064,23 +1072,25 @@ void updateAttrs(Map a, Map b, Map attrs) {
       // find all modified and removed
       a.forEach((key, value) {
         final bValue = b[key];
-        if (bValue == null) {
+        if (bValue == null || bValue == false) {
           attrs.remove(key);
         } else if (value != bValue) {
-          attrs[key] = bValue;
+          _setAttr(attrs, key, bValue);
         }
       });
 
       // find all inserted
       b.forEach((key, value) {
         if (!a.containsKey(key)) {
-          attrs[key] = value;
+          _setAttr(attrs, key, value);
         }
       });
     }
   } else if (b != null && b.length > 0) {
     // all keys inserted
-    attrs.addAll(b);
+    b.forEach((key, value) {
+      _setAttr(attrs, key, value);
+    });
   }
 }
 

--- a/lib/src/vnode.dart
+++ b/lib/src/vnode.dart
@@ -54,7 +54,7 @@ class VNode {
   String type;
 
   /// Attributes.
-  Map<String, String> attrs;
+  Map<String, dynamic> attrs;
 
   /// Styles.
   Map<String, String> style;
@@ -192,6 +192,14 @@ class VNode {
 
       if (attrs != null) {
         attrs.forEach((k, v) {
+          if (v is num) {
+            v = v.toString();
+          } else if (v is bool) {
+            if (!v) {
+              return;
+            }
+            v = '';
+          }
           r.attributes[k] = v;
         });
       }

--- a/test/test_vdom.dart
+++ b/test/test_vdom.dart
@@ -89,6 +89,25 @@ void main() {
         expect(frag.innerHtml,
             equals('<div id="test-id" data-test="test-data"></div>'));
       });
+
+      test('Create textarea with numeric attributes', () {
+        final frag = new html.DocumentFragment();
+        final n = ve('textarea', attrs: {'rows': 2, 'cols': 20});
+        injectVNodeSync(n, frag);
+        expect(frag.innerHtml, equals('<textarea rows="2" cols="20"></textarea>'));
+      });
+
+      test('Create checkbox with boolean attribute', () {
+        final frag = new html.DocumentFragment();
+        final n = ve('input', attrs: {'type': 'checkbox', 'checked': true});
+        injectVNodeSync(n, frag);
+        expect(frag.innerHtml, equals('<input type="checkbox" checked="">'));
+
+        final frag2 = new html.DocumentFragment();
+        final n2 = ve('input', attrs: {'type': 'checkbox', 'checked': false});
+        injectVNodeSync(n2, frag2);
+        expect(frag2.innerHtml, equals('<input type="checkbox">'));
+      });
     });
 
     group('Styles', () {

--- a/test/test_vdom.dart
+++ b/test/test_vdom.dart
@@ -1055,6 +1055,28 @@ void main() {
       expect((f.firstChild as html.Element).attributes['c'], equals('3'));
     });
 
+    test('{} => {a: true, b: false}', () {
+      final f = new html.DocumentFragment();
+      final a = ve('div', attrs: {});
+      final b = ve('div', attrs: {'a': true, 'b': false});
+      injectVNodeSync(a, f);
+      a.update(b, const VContext(true));
+      expect((f.firstChild as html.Element).attributes.isNotEmpty, isTrue);
+      expect((f.firstChild as html.Element).attributes.length, 1);
+      expect((f.firstChild as html.Element).attributes['a'], equals(''));
+    });
+
+    test('{} => {a: num 1}', () {
+      final f = new html.DocumentFragment();
+      final a = ve('div', attrs: {});
+      final b = ve('div', attrs: {'a': 1});
+      injectVNodeSync(a, f);
+      a.update(b, const VContext(true));
+      expect((f.firstChild as html.Element).attributes.isNotEmpty, isTrue);
+      expect((f.firstChild as html.Element).attributes.length, 1);
+      expect((f.firstChild as html.Element).attributes['a'], equals('1'));
+    });
+
     test('{a: 1} => null', () {
       final f = new html.DocumentFragment();
       final a = ve('div', attrs: {'a': '1'});
@@ -1126,6 +1148,92 @@ void main() {
       expect((f.firstChild as html.Element).attributes.length, 2);
       expect((f.firstChild as html.Element).attributes['a'], equals('10'));
       expect((f.firstChild as html.Element).attributes['b'], equals('20'));
+    });
+
+    test('{a: false} => {a: true}', () {
+      final f = new html.DocumentFragment();
+      final a = ve('div', attrs: {'a': false});
+      final b = ve('div', attrs: {'a': true});
+      injectVNodeSync(a, f);
+      a.update(b, const VContext(true));
+      expect((f.firstChild as html.Element).attributes.isNotEmpty, isTrue);
+      expect((f.firstChild as html.Element).attributes.length, 1);
+      expect((f.firstChild as html.Element).attributes['a'], equals(''));
+    });
+
+    test('{a: true} => {a: false}', () {
+      final f = new html.DocumentFragment();
+      final a = ve('div', attrs: {'a': true});
+      final b = ve('div', attrs: {'a': false});
+      injectVNodeSync(a, f);
+      a.update(b, const VContext(true));
+      expect((f.firstChild as html.Element).attributes.isNotEmpty, isFalse);
+      expect((f.firstChild as html.Element).attributes.length, 0);
+    });
+
+    test('{a: num 1} => {a: num 10}', () {
+      final f = new html.DocumentFragment();
+      final a = ve('div', attrs: {'a': 1});
+      final b = ve('div', attrs: {'a': 10});
+      injectVNodeSync(a, f);
+      a.update(b, const VContext(true));
+      expect((f.firstChild as html.Element).attributes.isNotEmpty, isTrue);
+      expect((f.firstChild as html.Element).attributes.length, 1);
+      expect((f.firstChild as html.Element).attributes['a'], equals('10'));
+    });
+
+    test('{a: num 1} => {a: false}', () {
+      final f = new html.DocumentFragment();
+      final a = ve('div', attrs: {'a': 1});
+      final b = ve('div', attrs: {'a': false});
+      injectVNodeSync(a, f);
+      a.update(b, const VContext(true));
+      expect((f.firstChild as html.Element).attributes.isNotEmpty, isFalse);
+      expect((f.firstChild as html.Element).attributes.length, 0);
+    });
+
+    test('{a: num 1} => {a: true}', () {
+      final f = new html.DocumentFragment();
+      final a = ve('div', attrs: {'a': 1});
+      final b = ve('div', attrs: {'a': true});
+      injectVNodeSync(a, f);
+      a.update(b, const VContext(true));
+      expect((f.firstChild as html.Element).attributes.isNotEmpty, isTrue);
+      expect((f.firstChild as html.Element).attributes.length, 1);
+      expect((f.firstChild as html.Element).attributes['a'], equals(''));
+    });
+
+    test('{a: false} => {a: 1}', () {
+      final f = new html.DocumentFragment();
+      final a = ve('div', attrs: {'a': false});
+      final b = ve('div', attrs: {'a': '1'});
+      injectVNodeSync(a, f);
+      a.update(b, const VContext(true));
+      expect((f.firstChild as html.Element).attributes.isNotEmpty, isTrue);
+      expect((f.firstChild as html.Element).attributes.length, 1);
+      expect((f.firstChild as html.Element).attributes['a'], equals('1'));
+    });
+
+    test('{a: false} => {a: num 1}', () {
+      final f = new html.DocumentFragment();
+      final a = ve('div', attrs: {'a': false});
+      final b = ve('div', attrs: {'a': 1});
+      injectVNodeSync(a, f);
+      a.update(b, const VContext(true));
+      expect((f.firstChild as html.Element).attributes.isNotEmpty, isTrue);
+      expect((f.firstChild as html.Element).attributes.length, 1);
+      expect((f.firstChild as html.Element).attributes['a'], equals('1'));
+    });
+
+    test('{a: true} => {a: 1}', () {
+      final f = new html.DocumentFragment();
+      final a = ve('div', attrs: {'a': true});
+      final b = ve('div', attrs: {'a': '1'});
+      injectVNodeSync(a, f);
+      a.update(b, const VContext(true));
+      expect((f.firstChild as html.Element).attributes.isNotEmpty, isTrue);
+      expect((f.firstChild as html.Element).attributes.length, 1);
+      expect((f.firstChild as html.Element).attributes['a'], equals('1'));
     });
   });
 


### PR DESCRIPTION
Add support for numeric or boolean values in attrs.
#### Use cases
##### boolean

`input[type="checkbox"]` is checked if there is a checked attribute, no matter the value. Currently one need a bit of boilerplate to handle checkboxes, supporting a boolean value directly is much nicer.
##### numeric

When working with SVG I use a lot of calculations to set x, y and similar attributes, having to call `.toString()` isn't quite as bad as the checkbox but it would still be nice with support for numbers.
