### PR TITLE
Fix updating implicit children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.7.1
+- Fixed issue in updating implicit children.
+
 # 0.7.0
 
 - Added support for namespaced attributes.

--- a/lib/src/vdom/vnode.dart
+++ b/lib/src/vdom/vnode.dart
@@ -826,7 +826,7 @@ void _updateImplicitChildren(VNode parent, List<VNode> a, List<VNode> b, VContex
   }
 
   final nextPos = bEnd + 1;
-  final next = nextPos < b.length ? b[nextPos].ref : null;
+  final next = nextPos < b.length ? b[nextPos] : null;
 
   // All nodes from [b] are updated, remove the rest from [a].
   while (bStart <= bEnd) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: uix
-version: 0.7.0
+version: 0.7.1
 author: Boris Kaul <localvoid@gmail.com>
 description: Library to build Web User Interfaces inspired by React.
 homepage: https://github.com/localvoid/uix


### PR DESCRIPTION
Fix small typo in `_updateImplicitChildren` method. `_insertChild` expects `VNode` and fails on `Node`.